### PR TITLE
feature(backend): Made leaderboard return a JSON #109

### DIFF
--- a/backend/src/data-access/db.ts
+++ b/backend/src/data-access/db.ts
@@ -42,8 +42,23 @@ export class Database{
         return this.recentRank;
     }
 
-    getLeaderboard(): Array<Entry>{
-        return this.data.slice(0, 10);
+    getLeaderboard(): string{
+        class leaderboardResult{
+            rank: number;
+            name: string;
+            score: number;
+            constructor(rank: number, name: string, score: number){
+                this.rank = rank;
+                this.name = name;
+                this.score = score
+            }
+        };
+        let entryLeaderboard = this.data.slice(0, 10);
+        let modLeaderboard: Array<leaderboardResult> = [];
+        entryLeaderboard.forEach((e)=>{
+            modLeaderboard.push(new leaderboardResult(entryLeaderboard.indexOf(e)+ 1, e.name, e.score));
+        })
+        return JSON.stringify(modLeaderboard);
     }
         
 }

--- a/backend/test/database.test.ts
+++ b/backend/test/database.test.ts
@@ -13,5 +13,6 @@ describe("Database", () => {
         for (let i = 0; i < 0; i++){
             db.addData("name "+ i, i );
         }
+        //console.log(db.getLeaderboard());
     })
 });


### PR DESCRIPTION
Closes #109

Example JSON output of leaderboard:
[{"rank":1,"name":"name 82","score":82},{"rank":2,"name":"name 82","score":82},{"rank":3,"name":"name 82","score":82},{"rank":4,"name":"name 82","score":82},{"rank":5,"name":"name 82","score":82},{"rank":6,"name":"name 82","score":82},{"rank":7,"name":"name 81","score":81},{"rank":8,"name":"name 81","score":81},{"rank":9,"name":"name 81","score":81},{"rank":10,"name":"name 81","score":81}]