### PR TITLE
make an api endpoint to get only the global leaderboard (issue #214)

### DIFF
--- a/backend/src/api/api.ts
+++ b/backend/src/api/api.ts
@@ -107,6 +107,11 @@ export class api {
                 ws.send(ApiResponseFactory.practiceQuestionResponse(JSON.stringify(new GameLogic().generateQuestion(false))))
                 break;
 
+            case (ApiPaths.LEADERBOARD):
+                // Send leaderboard here
+                
+                break;
+
             default:
                 ws.send("Error: path not found");
         }
@@ -291,4 +296,5 @@ class ApiPaths {
     static JOIN_LOBBY = '/api/v1/lobby/join';
     static REJOIN_LOBBY = '/api/v1/lobby/rejoin';
     static PRACTICE = '/api/v1/practice';
+    static LEADERBOARD = '/api/v1/leaderboard';
 }

--- a/backend/src/api/api.ts
+++ b/backend/src/api/api.ts
@@ -9,6 +9,7 @@ import { Lobby } from '../data-access/lobby';
 import { ApiResponseFactory } from './apiResponseFactory';
 import { Player } from '../data-access/player';
 import {GameLogic} from '../session-logic/gameLogic';
+import { Database } from "../data-access/db";
 
 
 export class api {
@@ -109,7 +110,8 @@ export class api {
 
             case (ApiPaths.LEADERBOARD):
                 // Send leaderboard here
-                
+                console.log("Sending only global leaderboard");
+                ws.send(ApiResponseFactory.getLeaderboardResponse(new Database().getLeaderboard()))
                 break;
 
             default:


### PR DESCRIPTION
closes #214 

Adds an API endpoint that will send the global leaderboard without requiring a pre-existing connection. This should allow for the creation of a leaderboard on or accessible from the home page.