### PR TITLE
make the api leaderboard response match the spec (issue #216)

### DIFF
--- a/backend/src/api/api.ts
+++ b/backend/src/api/api.ts
@@ -221,7 +221,7 @@ export class api {
             return;
         }
 
-        ws.send(ApiResponseFactory.getLeaderboardResponse(lobby.database.getLeaderboard()));
+        ws.send(ApiResponseFactory.getLeaderboardResponse(lobby.database.getLeaderboard(), lobby.getLeaderboard()));
 
     }
 

--- a/backend/src/api/apiResponseFactory.ts
+++ b/backend/src/api/apiResponseFactory.ts
@@ -149,11 +149,12 @@ export class ApiResponseFactory {
         `;
     }
 
-    static getLeaderboardResponse(leaderboard: string): string {
+    static getLeaderboardResponse(leaderboard: string, lobbyLeaderboard?: string): string {
         return `
         {
             "type": "LEADERBOARD",
             "leaderboard": ${leaderboard ?? "\"[]\""} 
+            "lobbyLeaderboard": ${lobbyLeaderboard ?? "\"[]\""}
         }
         `;
     }

--- a/backend/src/api/apiResponseFactory.ts
+++ b/backend/src/api/apiResponseFactory.ts
@@ -153,7 +153,7 @@ export class ApiResponseFactory {
         return `
         {
             "type": "LEADERBOARD",
-            "leaderboard": ${leaderboard ?? "\"[]\""} 
+            "leaderboard": ${leaderboard ?? "\"[]\""},
             "lobbyLeaderboard": ${lobbyLeaderboard ?? "\"[]\""}
         }
         `;

--- a/docs/backend/api-specification.md
+++ b/docs/backend/api-specification.md
@@ -224,8 +224,8 @@ nickname, score, questions
 ```json
 {
   "action": "GET_LEADERBOARD",
-  data: {
-    lobbyId: "ajsdlf"
+  "data": {
+    "lobbyId": "ajsdlf"
   }
 }
 ```
@@ -236,7 +236,7 @@ nickname, score, questions
   "leaderboard": [
         {"rank": "1", "name": "Donald", "score": "10"}
     ],
-    "lobbyLeaderboard": [
+    "lobbyLeaderboard": [ // Will be empty if no lobbyId is supplied
       {"rank": "1", "name": "Ronald", "score": "9"}
     ]
 }


### PR DESCRIPTION
closes #216 

When there is no previous connection will send a response with a global leaderboard and a empty local leaderboard which should be ignored.

When there is a previous connection and a lobby code is supplied will send a response with a global leaderboard and the local leaderboard